### PR TITLE
CI: Fix warnings & deprecation messages in GitHub actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+# Basic dependabot.yml file with
+# minimum configuration for two package managers
+
+version: 2
+updates:
+
+  # Enable version updated for GitHub actions used in workflows 
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"
+
+  # Enable version updates for npm
+  - package-ecosystem: "npm"
+    # Look for `package.json` and `lock` files in the `internal/lookout` directory
+    directory: "/"
+    # Check the npm registry for updates monthly
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/aws_sam.yml
+++ b/.github/workflows/aws_sam.yml
@@ -5,20 +5,23 @@ on:
       - main
   workflow_dispatch:
 
+env:
+  NODE_VERSION: 20
+
 jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
     environment: protected
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Echo config to file
         run: echo "${{ vars.CONFIG }}" > ./config.yml
       
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: ${{ env.NODE_VERSION }}
           cache: npm
       
       - name: Install Dependencies
@@ -33,14 +36,14 @@ jobs:
     environment: protected
     needs: test
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Echo config to file
         run: echo "${{ vars.CONFIG }}" > ./config.yml
       
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: ${{ env.NODE_VERSION }}
           cache: npm
       
       - name: Build docker image


### PR DESCRIPTION
### What type of PR is this?

CI: Resolve deprecation & warning messages in workflows

### What this PR does / why we need it:

`Node16` has been out of support since [September 2023](https://github.com/nodejs/Release/#end-of-life-releases). - more info in the [post](https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/) 

- Add GitHub actions for DependaBot - [commit](https://github.com/gr-oss-devops/ghrunner-app/pull/1/commits/358a177b5ade90e628ccab1cf87151b434f50f7f)
- Bump the steps where deprecation/warnings are shown in the job - [commit](https://github.com/gr-oss-devops/ghrunner-app/pull/1/commits/7891c71a93d7dca42220134134c343d32cd7b91c)

### Which issue(s) this PR fixes:
Fixes: https://github.com/G-Research/gr-oss/issues/608


------------

# Testing results

Per the [latest run](https://github.com/pavlovic-ivan/ghrunner-app/actions/runs/8019025396) of the workflow reported deprecation warnings are 

- actions/checkout@v3
- actions/setup-node@v3

## PASSED 🟢 

**Deploy the lambda using AWS SAM**
 - In workflow below, mentioned steps are not shown as warnings/deprecations: https://github.com/gr-oss-devops/ghrunner-app/actions/runs/8267899074/job/22619490173
